### PR TITLE
Getting parsed org and transforming to Text (HTML)

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,10 +20,24 @@ jobs:
       with:
         ghc-version: '9.6.3'
         enable-stack: true
+    - uses: actions/cache@v3
+      name: Cache ~/.stack
+      with:
+        path: ~/.stack
+        key: ${{ runner.os }}-stack-global-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-stack-global-
+    - uses: actions/cache@v3
+      name: Cache .stack-work
+      with:
+        path: .stack-work
+        key: ${{ runner.os }}-stack-work-${{ hashFiles('stack.yaml.lock') }}-${{ hashFiles('**/*.hs') }}
+        restore-keys: |
+          ${{ runner.os }}-stack-work-
 
     - name: Build dependencies
-      run: stack build --only-dependencies
+      run: stack build --only-dependencies --system-ghc
     - name: Build
-      run: stack build
+      run: stack build --system-ghc
     - name: Run tests
-      run: stack test
+      run: stack test --system-ghc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+[![Haskell CI](https://github.com/paradoja/org2podcast/actions/workflows/haskell.yml/badge.svg)](https://github.com/paradoja/org2podcast/actions/workflows/haskell.yml)
+
 # org2podcast

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,5 +2,14 @@ module Main (main) where
 
 import Lib
 
+{-
+1. read file passed by params
+2. parse file and transform to local datatype (ParseOrg.hs)
+3. get media data from local datatype and get media info from them (MediaInfo.hs)
+4. pass it all to podcast RSS/Atom builder (Podcast.hs)
+5. Either print to stdout or write to file.
+6. ...
+7. Profit!
+-}
 main :: IO ()
 main = someFunc

--- a/org2podcast.cabal
+++ b/org2podcast.cabal
@@ -26,6 +26,7 @@ source-repository head
 library
   exposed-modules:
       Lib
+      ParseOrg
   other-modules:
       Paths_org2podcast
   autogen-modules:
@@ -35,7 +36,13 @@ library
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       base >=4.7 && <5
+    , containers
+    , lucid
+    , megaparsec
     , org-mode
+    , org-mode-lucid
+    , text
+    , time
   default-language: Haskell2010
 
 executable org2podcast
@@ -56,6 +63,7 @@ test-suite org2podcast-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      ParseOrgSpec
       Paths_org2podcast
   autogen-modules:
       Paths_org2podcast
@@ -64,7 +72,11 @@ test-suite org2podcast-test
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
+    , containers
     , hspec
     , hspec-contrib
+    , org-mode
     , org2podcast
+    , text
+    , time
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,12 @@ library:
   source-dirs: src
   dependencies:
   - org-mode
+  - text
+  - containers
+  - time
+  - org-mode-lucid
+  - lucid
+  - megaparsec
 
 executables:
   org2podcast:
@@ -61,3 +67,7 @@ tests:
     - org2podcast
     - hspec
     - hspec-contrib
+    - org-mode
+    - containers
+    - text
+    - time

--- a/src/ParseOrg.hs
+++ b/src/ParseOrg.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Description XXX TODO yes, we redo a lot of the transforming
+-- I tried using org-mode date parsing but it's shit
+module ParseOrg (Entries, Meta (..), Entry (..), text2entries) where
+
+import Data.List.NonEmpty (NonEmpty ((:|)), nonEmpty)
+import qualified Data.Map as M
+import Data.Maybe (fromJust, maybe, fromMaybe)
+import Data.Org
+import qualified Data.Org.Lucid as OL
+import Data.Text as T
+import Data.Text.Lazy (toStrict)
+import Data.Time
+import Data.Void (Void)
+import Lucid
+import Text.Megaparsec
+import Text.Megaparsec.Char
+import           Text.Megaparsec.Char.Lexer (decimal)
+
+type Parser = Parsec Void T.Text -- for parsing the datetime
+
+data Entry = Entry
+  { entryTitle :: !Text,
+    entryDate :: !UTCTime,
+    mediaName :: !Text,
+    body :: !Text
+  }
+  deriving (Eq, Show)
+
+data Meta = Meta
+  { title :: !Text,
+    description :: !Text,
+    email :: !Text,
+    fileLocation :: !Text, -- should be a Path
+    feedURL :: !Text,
+    imageURL :: !Text,
+    filesURL :: !Text
+  }
+  deriving (Eq, Show)
+
+type Entries = (Meta, [Entry])
+
+text2entries :: Text -> Entries
+text2entries = org2entries . fromJust . org
+
+renderingOptions :: OL.OrgStyle
+renderingOptions =
+  OL.OrgStyle
+    { OL.includeTitle = False,
+      OL.tableOfContents = OL.TOC 0,
+      OL.bootstrap = False,
+      OL.bulma = False,
+      OL.highlighting = OL.codeHTML,
+      OL.sectionStyling = \_ a b -> a >> b,
+      OL.separator = Just ' '
+    }
+
+org2entries :: OrgFile -> Entries
+org2entries
+  ( OrgFile
+      { orgMeta = oMeta,
+        orgDoc =
+          OrgDoc
+            { docBlocks = _, -- TODO ??
+              docSections = sections
+            }
+      }
+    ) =
+    let meta = fromJust $ map2Meta oMeta -- TODO fromJust?
+     in (meta, fmap mainSection2Entry sections)
+
+map2Meta :: M.Map Text Text -> Maybe Meta
+map2Meta metaMap = do
+  description' <- M.lookup "DESCRIPTION" metaMap
+  email' <- M.lookup "EMAIL" metaMap
+  fileLocation' <- M.lookup "FILE_LOCATION" metaMap
+  feedURL' <- M.lookup "RSS_FEED_URL" metaMap
+  imageURL' <- M.lookup "RSS_IMAGE_URL" metaMap
+  filesURL' <- M.lookup "RSS_FILES_URL" metaMap
+  title' <- M.lookup "RSS_TITLE" metaMap
+  return $
+    Meta title' description' email' fileLocation' feedURL' imageURL' filesURL'
+
+mainSection2Entry :: Section -> Entry
+mainSection2Entry
+  ( Section
+      { sectionHeading = hHead :| hRest,
+        sectionProps = properties,
+        sectionDoc =
+          orgDoc@OrgDoc
+            { docBlocks = innerBlocks,
+              docSections = innerSections
+            }
+      }
+    ) =
+    let media = fromJust $ M.lookup "MEDIA" properties
+        pubDate = fromJust $ M.lookup "PUBDATE" properties
+     in Entry
+          { entryTitle = wordList2Text (hHead : hRest),
+            entryDate =
+              let maybeStamp = parseMaybe timestampParser $ pubDate
+               in fromJust maybeStamp,
+            mediaName = media,
+            body =
+              toStrict . renderText $ OL.body renderingOptions (OrgFile {orgMeta = M.empty, orgDoc = orgDoc})
+          }
+
+wordList2Text :: [Words] -> Text
+wordList2Text = T.intercalate " " . fmap words2Text
+
+words2Text :: Words -> Text
+words2Text (Bold text) = "<b>" <> text <> "</b>"
+words2Text (Italic text) = "<i>" <> text <> "</i>"
+words2Text (Highlight text) = "<span style='text-decoration: underline;'>" <> text <> "</span>"
+words2Text (Underline text) = "<span style='text-decoration: underline;'>" <> text <> "</span>"
+words2Text (Verbatim text) = "<pre>" <> text <> "</pre>"
+words2Text (Strike text) = "<s>" <> text <> "</s>"
+words2Text (Link (URL url) (Just text)) = "<a href='" <> url <> "'>" <> text <> "</a>"
+words2Text (Link (URL url) Nothing) = "<a href='" <> url <> "'>" <> url <> "</a>"
+words2Text (Image (URL url)) = "<img src='" <> url <> "'>"
+words2Text (Punct char) = singleton char
+words2Text (Plain text) = text
+
+-- Timestampr parser
+
+timestampParser :: Parser UTCTime
+timestampParser = do
+  char '<'
+  day <- dateParser
+  space1
+  many letterChar
+  space
+  time <- optional timeParser
+  char '>'
+  return $ UTCTime day (timeOfDayToTime (fromMaybe (TimeOfDay 0 0 0) time))
+
+dateParser :: Parser Day
+dateParser = fromGregorian <$> decimal <*> (char '-' *> decimal) <*> (char '-' *> decimal)
+
+timeParser :: Parser TimeOfDay
+timeParser = do
+  hour <- decimal
+  char ':'
+  minutes <- decimal
+  seconds <- optional (char ':' >> decimal)
+  return $ TimeOfDay hour minutes (fromMaybe 0 seconds)

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,6 +39,8 @@ extra-deps:
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 - org-mode-2.1.0@sha256:984a08d2cebcfebfb4e858d27abb2eec7d6797cd005af7bcfa0d84ed465333ce,1452
+- org-mode-lucid-1.7.0@sha256:c35423565c67e7f2c2c64f66c5e57b55b13c632bc54ec0a1dc0b59c538987ab5,1030
+
 #
 # extra-deps: []
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -11,6 +11,13 @@ packages:
       size: 428
   original:
     hackage: org-mode-2.1.0@sha256:984a08d2cebcfebfb4e858d27abb2eec7d6797cd005af7bcfa0d84ed465333ce,1452
+- completed:
+    hackage: org-mode-lucid-1.7.0@sha256:c35423565c67e7f2c2c64f66c5e57b55b13c632bc54ec0a1dc0b59c538987ab5,1030
+    pantry-tree:
+      sha256: 1d59ecaeb69d2aa716fd0eb04a8c2262fa09beaa1c74d1584a7c40cdfa6e0c5d
+      size: 275
+  original:
+    hackage: org-mode-lucid-1.7.0@sha256:c35423565c67e7f2c2c64f66c5e57b55b13c632bc54ec0a1dc0b59c538987ab5,1030
 snapshots:
 - completed:
     sha256: 1b4c2669e26fa828451830ed4725e4d406acc25a1fa24fcc039465dd13d7a575

--- a/test/ParseOrgSpec.hs
+++ b/test/ParseOrgSpec.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -fno-warn-missing-export-lists #-}
 
--- | Description? XXX TODO
 module ParseOrgSpec where
 
-import Data.List.NonEmpty
-import qualified Data.Map as M
-import Data.Org
 import qualified Data.Text as T
 import Data.Time
 import ParseOrg
@@ -15,7 +13,7 @@ testMeta :: T.Text
 testMeta =
   T.concat $
     fmap
-      (\l -> l <> "\n")
+      (<> "\n")
       [ "#+RSS_TITLE: A nice podcast title",
         "#+EMAIL: person@example.net",
         "#+DESCRIPTION: Podcast description",
@@ -25,6 +23,7 @@ testMeta =
         "#+RSS_FILES_URL: https://podcast.example.net/files/"
       ]
 
+testContent :: T.Text
 testContent =
   T.intercalate
     "\n"
@@ -49,6 +48,7 @@ testContent =
       "In the sub sub section"
     ]
 
+myFirstDate, mySecondDate :: UTCTime
 myFirstDate =
   UTCTime
     (fromGregorian 2024 2 6)
@@ -58,8 +58,10 @@ mySecondDate =
     (fromGregorian 2023 2 6)
     (timeOfDayToTime (TimeOfDay 13 31 0))
 
-(myMeta, myEntries) = text2entries $ testMeta <> testContent
-
+myMeta :: Meta
+myEntries :: [Entry]
+myFirstEntry, mySecondEntry :: Entry
+Right (myMeta, myEntries) = orgText2entries $ testMeta <> testContent
 myFirstEntry : mySecondEntry : _ = myEntries
 
 spec :: Spec
@@ -68,7 +70,7 @@ spec = do
     it "gets fields correctly" $ do
       myMeta
         `shouldBe` ( Meta
-                       { title = "A nice podcast title",
+                       { podcastTitle = "A nice podcast title",
                          email = "person@example.net",
                          description = "Podcast description",
                          fileLocation = "file_path",
@@ -79,17 +81,17 @@ spec = do
                    )
   describe "parsing entries" $ do
     it "parses entryTitle correctly" $ do
-      (entryTitle myFirstEntry) `shouldBe` "This is a header"
-      (entryTitle mySecondEntry) `shouldBe` "Another"
+      entryTitle myFirstEntry `shouldBe` "This is a header"
+      entryTitle mySecondEntry `shouldBe` "Another"
     it "parses entryDate correctly" $ do
-      (entryDate myFirstEntry) `shouldBe` myFirstDate
-      (entryDate mySecondEntry) `shouldBe` mySecondDate
+      entryDate myFirstEntry `shouldBe` myFirstDate
+      entryDate mySecondEntry `shouldBe` mySecondDate
     it "parses mediaName correctly" $ do
-      (mediaName myFirstEntry) `shouldBe` "file.mp3"
-      (mediaName mySecondEntry) `shouldBe` "file2.mp3"
+      mediaName myFirstEntry `shouldBe` "file.mp3"
+      mediaName mySecondEntry `shouldBe` "file2.mp3"
     it "parses body correctly" $ do
-      (body myFirstEntry) `shouldBe` "<p>And some text</p>"
-      (body mySecondEntry)
+      body myFirstEntry `shouldBe` "<p>And some text</p>"
+      body mySecondEntry
         `shouldSatisfy` ( \b ->
                             all
                               (`T.isInfixOf` b)

--- a/test/ParseOrgSpec.hs
+++ b/test/ParseOrgSpec.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Description? XXX TODO
+module ParseOrgSpec where
+
+import Data.List.NonEmpty
+import qualified Data.Map as M
+import Data.Org
+import qualified Data.Text as T
+import Data.Time
+import ParseOrg
+import Test.Hspec
+
+testMeta :: T.Text
+testMeta =
+  T.concat $
+    fmap
+      (\l -> l <> "\n")
+      [ "#+RSS_TITLE: A nice podcast title",
+        "#+EMAIL: person@example.net",
+        "#+DESCRIPTION: Podcast description",
+        "#+FILE_LOCATION: file_path",
+        "#+RSS_FEED_URL: https://podcast.example.net/feed.xml",
+        "#+RSS_IMAGE_URL: https://podcast.example.net/icon.png",
+        "#+RSS_FILES_URL: https://podcast.example.net/files/"
+      ]
+
+testContent =
+  T.intercalate
+    "\n"
+    [ "* This is a header",
+      ":PROPERTIES:",
+      ":PUBDATE: <2024-02-06 Di 11:31>",
+      ":MEDIA:   file.mp3",
+      ":END:",
+      "And some text",
+      "",
+      "* Another",
+      ":PROPERTIES:",
+      ":PUBDATE: <2023-02-06 Di 13:31>",
+      ":MEDIA:   file2.mp3",
+      ":END:",
+      "Some text",
+      "",
+      "** Sub section",
+      "In the subsection",
+      "",
+      "*** Sub sub section",
+      "In the sub sub section"
+    ]
+
+myFirstDate =
+  UTCTime
+    (fromGregorian 2024 2 6)
+    (timeOfDayToTime (TimeOfDay 11 31 0))
+mySecondDate =
+  UTCTime
+    (fromGregorian 2023 2 6)
+    (timeOfDayToTime (TimeOfDay 13 31 0))
+
+(myMeta, myEntries) = text2entries $ testMeta <> testContent
+
+myFirstEntry : mySecondEntry : _ = myEntries
+
+spec :: Spec
+spec = do
+  describe "parsing metadata" $ do
+    it "gets fields correctly" $ do
+      myMeta
+        `shouldBe` ( Meta
+                       { title = "A nice podcast title",
+                         email = "person@example.net",
+                         description = "Podcast description",
+                         fileLocation = "file_path",
+                         feedURL = "https://podcast.example.net/feed.xml",
+                         imageURL = "https://podcast.example.net/icon.png",
+                         filesURL = "https://podcast.example.net/files/"
+                       }
+                   )
+  describe "parsing entries" $ do
+    it "parses entryTitle correctly" $ do
+      (entryTitle myFirstEntry) `shouldBe` "This is a header"
+      (entryTitle mySecondEntry) `shouldBe` "Another"
+    it "parses entryDate correctly" $ do
+      (entryDate myFirstEntry) `shouldBe` myFirstDate
+      (entryDate mySecondEntry) `shouldBe` mySecondDate
+    it "parses mediaName correctly" $ do
+      (mediaName myFirstEntry) `shouldBe` "file.mp3"
+      (mediaName mySecondEntry) `shouldBe` "file2.mp3"
+    it "parses body correctly" $ do
+      (body myFirstEntry) `shouldBe` "<p>And some text</p>"
+      (body mySecondEntry)
+        `shouldSatisfy` ( \b ->
+                            all
+                              (`T.isInfixOf` b)
+                              [ "Sub section</h2>",
+                                -- we start headings from h2
+                                "In the subsection",
+                                "Sub sub section</h3>",
+                                "In the sub sub section"
+                              ]
+                        )


### PR DESCRIPTION
Gets an org file passed as a Text, and returns an internal data type representing the information to send to the Atom library.