### PR TITLE
Clean cli app

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,54 +1,82 @@
 module Main (main) where
 
-import Data.Map
+import Data.Map (fromList)
+import qualified Data.Text as T
 import qualified Data.Text.IO as T
+import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.IO as TL
+import Data.Time (getCurrentTime)
 import EntriesAtom
 import MediaInfo
+import Options.Applicative
 import ParseOrg
-import Data.Time
 import System.Environment
 import System.Exit
-import System.IO
 
-{-
-1. read file passed by params
-2. parse file and transform to local datatype (ParseOrg.hs)
-3. get media data from local datatype and get media info from them (MediaInfo.hs)
-4. pass it all to podcast RSS/Atom builder (Podcast.hs)
-5. Either print to stdout or write to file.
-6. ...
-7. Profit!
--}
-getMediaInfoForFile :: Entry -> IO (FilePath, (MIME, SHA1, Length))
-getMediaInfoForFile (Entry {_mediaPath = mediaPath}) =
-  do -- TODO mediaPath should be relative to feed, take into account
-    Right mime <- getMimeForFile mediaPath -- TODO
-    sha1 <- getSHA1ForFile mediaPath
-    lengthBytes <- getLengthForFile mediaPath
-    return (mediaPath, (mime, sha1, lengthBytes))
+data Org2FeedConfig = Org2FeedConfig
+  { _orgFile :: !FilePath,
+    _feedFile :: !(Maybe FilePath),
+    _pretty :: !Bool
+  }
 
 main :: IO ()
 main = do
   programName <- getProgName
-  args <- getArgs
-  parseArgs programName args
+  let opts =
+        info
+          (org2feedArgs <**> helper)
+          ( fullDesc
+              <> progDesc "Transforms an org file into a podcast atom feed"
+              <> header programName
+          )
+  processFile =<< execParser opts
 
-processFile orgFile = do
+org2feedArgs :: Parser Org2FeedConfig
+org2feedArgs =
+  Org2FeedConfig
+    <$> argument
+      str
+      ( metavar "ORGFILE"
+          <> help "Source org file"
+      )
+    <*> optional
+      ( argument
+          str
+          ( metavar "FEEDFILE"
+              <> help "Dest. atom feed file; `stdout` used if not given"
+          )
+      )
+    <*> switch
+      ( long "pretty"
+          <> short 'p'
+          <> help "Pretty print (with lots of whitespace)"
+      )
+
+processFile :: Org2FeedConfig -> IO ()
+processFile (Org2FeedConfig orgFile maybeFeedFile pretty) = do
   contents <- T.readFile orgFile
   now <- getCurrentTime
-  let ( Right
-          entries@( _meta,
-                    entries' -- TODO horrible names
-                    )
-        ) = orgText2entries contents
-  mediaFiles <- fromList <$> mapM getMediaInfoForFile entries'
+  case orgText2entries contents of
+    Left errorMsg -> die $ T.unpack errorMsg
+    Right entries@(_meta, entries') -> do
+      mediaFiles <- fromList <$> mapM getMediaInfoForFile entries'
+      let maybeFeed = renderFeed (feedConfig pretty) (FeedData mediaFiles entries now)
+      case maybeFeed of
+        Just feed -> outProc maybeFeedFile feed >> exitSuccess
+        Nothing -> die "Error"
 
-  let maybeFeed = renderFeed prettyConfig (FeedData mediaFiles entries now)
-  case maybeFeed of
-    Just feed -> TL.putStrLn feed >> exitWith ExitSuccess
-    Nothing -> die "Error"
+feedConfig :: Bool -> FeedConfig
+feedConfig pretty = if pretty then prettyConfig else defaultConfig
 
-parseArgs _ [orgFile] = processFile orgFile
--- parseArgs _ [orgfile, feedFile] = undefined
-parseArgs progName _ = die $ "Usage: " ++ progName ++ " ORGFILE.org [FEED.xml]"
+outProc :: Maybe FilePath -> TL.Text -> IO ()
+outProc Nothing = TL.putStrLn
+outProc (Just feedFile) = TL.writeFile feedFile
+
+getMediaInfoForFile :: Entry -> IO (FilePath, (MIME, SHA1, Length))
+getMediaInfoForFile (Entry {_mediaPath = mediaPath}) =
+  do
+    -- TODO mediaPath should be relative to feed, take into account
+    Right mime <- getMimeForFile mediaPath -- TODO
+    sha1 <- getSHA1ForFile mediaPath
+    lengthBytes <- getLengthForFile mediaPath
+    return (mediaPath, (mime, sha1, lengthBytes))

--- a/org2podcast.cabal
+++ b/org2podcast.cabal
@@ -66,6 +66,7 @@ executable org2podcast
       base >=4.7 && <5
     , containers
     , filepath
+    , optparse-applicative
     , org2podcast
     , text
     , time

--- a/org2podcast.cabal
+++ b/org2podcast.cabal
@@ -65,6 +65,7 @@ executable org2podcast
   build-depends:
       base >=4.7 && <5
     , containers
+    , directory
     , filepath
     , optparse-applicative
     , org2podcast

--- a/package.yaml
+++ b/package.yaml
@@ -67,6 +67,7 @@ executables:
     - containers
     - filepath
     - time
+    - optparse-applicative
 
 tests:
   org2podcast-test:

--- a/package.yaml
+++ b/package.yaml
@@ -68,6 +68,7 @@ executables:
     - filepath
     - time
     - optparse-applicative
+    - directory
 
 tests:
   org2podcast-test:

--- a/src/EntriesAtom.hs
+++ b/src/EntriesAtom.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- TODO TEST
 module EntriesAtom
   ( FeedData (..),
     FeedConfig (..),


### PR DESCRIPTION
The CLI app itself now 

- Parses possible pretty printing options
- Prints a more helpful help message
- Prints error messages whenever it encounters errors

And general refactor to clean up warnings and possible runtime errors.